### PR TITLE
Reponds to AVPlayerItemDidPlayToEndTime event to currentItem only

### DIFF
--- a/MMPlayerView.podspec
+++ b/MMPlayerView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MMPlayerView'
-  s.version          = '6.0.3'
+  s.version          = '6.0.4'
   s.summary          = 'Custom Video Player view'
 
 # This description is used to generate tags and improve search results.

--- a/MMPlayerView.podspec
+++ b/MMPlayerView.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MMPlayerView'
-  s.version          = '6.0.2'
+  s.version          = '6.0.3'
   s.summary          = 'Custom Video Player view'
 
 # This description is used to generate tags and improve search results.

--- a/MMPlayerView/Classes/Swift/MMPlayerLayer.swift
+++ b/MMPlayerView/Classes/Swift/MMPlayerLayer.swift
@@ -222,6 +222,8 @@ public class MMPlayerLayer: AVPlayerLayer {
     public var isShrink: Bool {
         return shrinkControl.isShrink
     }
+	
+	var autoResume = true
     
     // MARK: - Private Parameter
     lazy var subtitleView = MMSubtitleView()
@@ -425,10 +427,18 @@ extension MMPlayerLayer {
         self.initStatus()
         self.asset = nil
     }
+	
+	public func pause() {
+		player?.pause()
+		currentPlayStatus = .pause
+		autoResume = false
+	}
+	
     /**
      Start player to play video
      */
     public func resume() {
+		autoResume = true
         switch self.currentPlayStatus {
         case .playing , .pause:
             if (self.player?.currentItem?.asset as? AVURLAsset)?.url == self.asset?.url {
@@ -598,7 +608,7 @@ extension MMPlayerLayer {
         })
         
         NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil, using: { [weak self] (nitification) in
-            if self?.isBackgroundPause == false {
+			if self?.isBackgroundPause == false && self?.autoResume == true {
                 self?.player?.play()
             }
             self?.isBackgroundPause = false

--- a/MMPlayerView/Classes/Swift/MMPlayerLayer.swift
+++ b/MMPlayerView/Classes/Swift/MMPlayerLayer.swift
@@ -604,22 +604,27 @@ extension MMPlayerLayer {
             self?.isBackgroundPause = false
         })
         
-        NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: nil, queue: nil, using: { [weak self] (_) in
-          
-            if self?.repeatWhenEnd == true {
-                self?.player?.seek(to: CMTime.zero)
-                self?.player?.play()
-            } else if let s = self?.currentPlayStatus {
-                switch s {
+        NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: nil, queue: nil, using: { [weak self] (notification) in
+			guard let self else { return }
+			
+            if repeatWhenEnd == true {
+				guard let player else { return }
+				guard let playItem = notification.object as? AVPlayerItem else { return }
+				guard playItem == player.currentItem else { return }
+                player.seek(to: .zero)
+                player.play()
+            } else {
+                switch currentPlayStatus {
                 case .playing, .pause:
-                    if let u = self?.asset?.url {
-                        self?.cahce.removeCache(key: u)
+                    if let u = asset?.url {
+                        cahce.removeCache(key: u)
                     }
-                    self?.currentPlayStatus = .end
+                    currentPlayStatus = .end
                 default: break
                 }
             }
         })
+		
         self.addObserver(self, forKeyPath: "videoRect", options: [.new, .old], context: nil)
         bgView.addObserver(self, forKeyPath: "frame", options: [.new, .old], context: nil)
         bgView.addObserver(self, forKeyPath: "bounds", options: [.new, .old], context: nil)


### PR DESCRIPTION
Right now if you have multi instances of MMPlayerLayer, one player ends will affect to all others.